### PR TITLE
Naming things: Adhere to the naming convention of https://llmtxt.dev/hub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 __pycache__
 bdist.*
 build/llm/*.txt
+build/llm/cratedb-overview.md

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 - Content: Added two pieces of content from blog articles, converted to Markdown format
 - Documentation: Started advertising to use the designated location
   https://cdn.crate.io/about/ for consuming the generated resources
+- Naming things: Adhered to the naming convention of [LLMs.txt Hub]
+  by using `llms.txt` and `llms-full.txt`.
 
 ## v0.0.1 - 2025-04-17
 - Established project layout
@@ -12,3 +14,6 @@
   (`uv run poe build`), and build artifacts (`llms-ctx.txt` and `llms-ctx-full.txt`)
 - Added CLI program `cratedb-about` with subcommands `ask` and `list-questions`
   for ad hoc conversations about CrateDB
+
+
+[LLMs.txt Hub]: https://llmtxt.dev/hub

--- a/build/llm/README.md
+++ b/build/llm/README.md
@@ -1,5 +1,7 @@
 # CrateDB's llms.txt
 
+## Introduction
+
 [llms.txt] is a proposal to standardise on using an `/llms.txt` file to provide
 information to help LLMs use a website at inference time. It is designed to
 coexist with current web standards.
@@ -8,6 +10,12 @@ While sitemaps list all pages for search engines, llms.txt offers a curated
 overview for LLMs. It can complement robots.txt by providing context for allowed
 content. The file can also reference structured data markup used on the site,
 helping LLMs understand how to interpret this information in context.
+
+## What's Inside
+
+- `cratedb-overview.md`: The source file for generating `llms.txt`.
+- `llms.txt`: Standard `llms.txt` file.
+- `llms-full.txt`: Full `llms.txt` file, including the "Optional" subsection.
 
 
 [llms.txt]: https://llmstxt.org/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,7 +165,7 @@ lint = [
 ]
 
 build = [
-  { shell = "cp src/index/cratedb-overview.md build/llm/llms.txt" },
-  { shell = "llms_txt2ctx --optional=false src/index/cratedb-overview.md > build/llm/llms-ctx.txt" },
-  { shell = "llms_txt2ctx --optional=true src/index/cratedb-overview.md > build/llm/llms-ctx-full.txt" },
+  { shell = "cp src/index/cratedb-overview.md build/llm/" },
+  { shell = "llms_txt2ctx --optional=false src/index/cratedb-overview.md > build/llm/llms.txt" },
+  { shell = "llms_txt2ctx --optional=true src/index/cratedb-overview.md > build/llm/llms-full.txt" },
 ]


### PR DESCRIPTION
https://llmtxt.dev/hub uses `llms.txt` and `llms-full.txt`. Let's use the same convention.
