### PR TITLE
Chore: Use `public_html` as build folder. `build` is used for Python.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,4 @@
 *.lock
 __pycache__
 bdist.*
-build/llm/*.txt
-build/llm/cratedb-overview.md
+public_html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,9 +165,9 @@ lint = [
 ]
 
 build = [
-  { shell = "mkdir -p build/llm" },
-  { shell = "cp src/index/cratedb-overview.md build/llm/" },
-  { shell = "cp src/content/about/llms-txt.md build/llm/readme.md" },
-  { shell = "llms_txt2ctx --optional=false src/index/cratedb-overview.md > build/llm/llms.txt" },
-  { shell = "llms_txt2ctx --optional=true src/index/cratedb-overview.md > build/llm/llms-full.txt" },
+  { shell = "mkdir -p public_html/llm" },
+  { shell = "cp src/index/cratedb-overview.md public_html/llm/" },
+  { shell = "cp src/content/about/llms-txt.md public_html/llm/readme.md" },
+  { shell = "llms_txt2ctx --optional=false src/index/cratedb-overview.md > public_html/llm/llms.txt" },
+  { shell = "llms_txt2ctx --optional=true src/index/cratedb-overview.md > public_html/llm/llms-full.txt" },
 ]


### PR DESCRIPTION
What the title says.