### PR TITLE
Outline: Make `cratedb-about outline` understand `--url` option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 # About CrateDB changelog
 
 ## Unreleased
+- CLI: `cratedb-about outline` now understands `--url` option to use
+  any outline resource on local or remote filesystems, or alternatively,
+  the `ABOUT_OUTLINE_URL` environment variable
 
 ## v0.0.3 - 2025-05-10
 - Data backend: Refactored the source of truth for the documentation outline

--- a/README.md
+++ b/README.md
@@ -55,10 +55,19 @@ uv tool install --upgrade 'cratedb-about[all] @ git+https://github.com/crate/abo
 ### Outline
 
 #### CLI
-Convert knowledge outline from `cratedb-outline.yaml` into Markdown format.
+Convert knowledge outline from builtin `cratedb-outline.yaml` into Markdown format.
 ```shell
 cratedb-about outline --format=markdown > outline.md
 ```
+Address custom outline file, both on local and remote filesystems.
+```shell
+cratedb-about outline --url https://github.com/crate/about/raw/refs/heads/main/src/cratedb_about/outline/cratedb-outline.yaml
+```
+Alternatively to the `--url` option, you can use the `ABOUT_OUTLINE_URL`
+environment variable. When using it, you will need to minimally install
+the package including its `manyio` extra like `cratedb-about[manyio]`.
+Then, you can address resources on many filesystems through the excellent
+[filesystem-spec] package.
 
 #### API
 Use the Python API to retrieve individual sets of outline items, for example,
@@ -68,8 +77,11 @@ documentation server, for example, a subsystem of [cratedb-mcp].
 ```python
 from cratedb_about import CrateDbKnowledgeOutline
 
-# Load information from YAML file.
+# Load information from builtin YAML file.
 outline = CrateDbKnowledgeOutline.load()
+
+# Load information from remote YAML file.
+# outline = CrateDbKnowledgeOutline.load("http://example.org/outline.yaml")
 
 # List available section names.
 outline.get_section_names()
@@ -135,6 +147,7 @@ GitHub]. Contributions of any kind are very much appreciated.
 [CrateDB]: https://cratedb.com/database
 [cratedb-mcp]: https://github.com/crate/cratedb-mcp
 [cratedb-outline.yaml]: https://github.com/crate/about/blob/main/src/cratedb_about/outline/cratedb-outline.yaml
+[filesystem-spec]: https://filesystem-spec.readthedocs.io/
 [llms.txt]: https://llmstxt.org/
 [Model Context Protocol (MCP)]: https://modelcontextprotocol.io/introduction
 

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,6 +1,9 @@
 # Backlog
 
 ## Iteration +1
+- `find_items`: Include or exclude multiple sections
+- `load`: Load from custom outline file
+- Refactor `llm_txt2ctx` shell-outs to API and `outline` subcommand
 - Let the user optionally select a local `llms.txt` file
 - Let the user select the model, reasoning effort, and other parameters
 - JSON/YAML/Markdown output

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -1,20 +1,25 @@
 # Backlog
 
 ## Iteration +1
-- `find_items`: Include or exclude multiple sections
-- `load`: Load from custom outline file
-- Refactor `llm_txt2ctx` shell-outs to API and `outline` subcommand
-- Let the user optionally select a local `llms.txt` file
-- Let the user select the model, reasoning effort, and other parameters
-- JSON/YAML/Markdown output
-- Revisit `notes` in `cratedb-outline.yaml`, for example about
-  pulling in `ctk docs functions` and `ctk docs settings`
+- Outline: Refactor `llm_txt2ctx` shell-outs to API, and add to `outline` subcommand
+- Outline: Refactor ingredients of `build` subcommand
+- Outline: Refactor quirky `as_dict` parameter to more fluent `.to_dict()` interface
+- Outline: Revisit `notes` in `cratedb-outline.yaml`, for example about
+  pulling in `ctk docs functions` and `ctk docs settings`, but also about
+  other resources that have not been expanded properly yet
 
 ## Iteration +2
-- Unlock Discourse, auto-select https://community.cratedb.com/raw/1015
-- Unlock HTML resources, auto-convert using the best standalone program.
+- Any: JSON/YAML/Markdown output
+- Query: Let the user optionally select a local or remote `llms.txt` file
+- Query: Let the user select the model, reasoning effort, and other parameters
+- Outline: `find_items`: Include and/or exclude multiple sections
+
+## Iteration +3
+- Outline: Unlock Discourse, auto-select https://community.cratedb.com/raw/1015
+- Outline: Unlock HTML resources, auto-convert using the best standalone program.
   => https://www.urltoany.com/url-to-markdown
-- Unlock GitHub projects: https://github.com/mattduck/gh2md
+- Outline: Unlock GitHub projects: https://github.com/mattduck/gh2md
 
 ## Done
-- Publish to PyPI
+- Package: Publish to PyPI
+- Outline: `load`: Load from custom outline file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
   "requests<3",
 ]
 optional-dependencies.all = [
-  "cratedb-about[llm]",
+  "cratedb-about[manyio,llm]",
 ]
 optional-dependencies.develop = [
   "mypy<1.16",
@@ -90,6 +90,9 @@ optional-dependencies.develop = [
 optional-dependencies.llm = [
   "claudette<0.2",
   "openai<2",
+]
+optional-dependencies.manyio = [
+  "pueblo[fileio]==0.0.11",
 ]
 optional-dependencies.release = [
   "build<2",

--- a/src/cratedb_about/cli.py
+++ b/src/cratedb_about/cli.py
@@ -22,15 +22,24 @@ def cli(ctx: click.Context) -> None:
 
 @cli.command()
 @click.option(
+    "--url",
+    "-u",
+    envvar="ABOUT_OUTLINE_URL",
+    type=str,
+    required=False,
+    default=None,
+    help="URL of the outline file. By default, the builtin outline is used.",
+)
+@click.option(
     "--format", "-f", "format_", type=click.Choice(["markdown", "yaml", "json"]), default="markdown"
 )
-def outline(format_: t.Literal["markdown", "yaml", "json"] = "markdown") -> None:
+def outline(url: str, format_: t.Literal["markdown", "yaml", "json"] = "markdown") -> None:
     """
     Display the outline of the CrateDB documentation.
 
     Available output formats: Markdown, YAML, JSON.
     """
-    cratedb_outline = CrateDbKnowledgeOutline.load()
+    cratedb_outline = CrateDbKnowledgeOutline.load(url=url)
     if format_ == "json":
         print(cratedb_outline.to_json())  # noqa: T201
     elif format_ == "yaml":

--- a/src/cratedb_about/cli.py
+++ b/src/cratedb_about/cli.py
@@ -6,7 +6,7 @@ import click
 from pueblo.util.cli import boot_click
 
 from cratedb_about.build.llmstxt import LllmsTxtBuilder
-from cratedb_about.outline.model import CrateDbKnowledgeOutline
+from cratedb_about.outline import CrateDbKnowledgeOutline
 from cratedb_about.query.core import CrateDbKnowledgeConversation
 from cratedb_about.query.model import Example
 

--- a/src/cratedb_about/outline/__init__.py
+++ b/src/cratedb_about/outline/__init__.py
@@ -1,5 +1,7 @@
-from .model import CrateDbKnowledgeOutline
+from .core import CrateDbKnowledgeOutline
+from .model import OutlineDocument
 
 __all__ = [
     "CrateDbKnowledgeOutline",
+    "OutlineDocument",
 ]

--- a/src/cratedb_about/outline/core.py
+++ b/src/cratedb_about/outline/core.py
@@ -1,8 +1,11 @@
+import dataclasses
+import typing as t
 from importlib import resources
 
 from cratedb_about.outline.model import OutlineDocument
 
 
+@dataclasses.dataclass
 class CrateDbKnowledgeOutline:
     """
     Load CrateDB knowledge outline from YAML file `cratedb-outline.yaml`.
@@ -13,7 +16,7 @@ class CrateDbKnowledgeOutline:
     Examples:
         ```python
         # Get raw YAML content
-        yaml_content = CrateDbKnowledgeOutline.read()
+        yaml_content = CrateDbKnowledgeOutline().read()
 
         # Load as structured document
         outline = CrateDbKnowledgeOutline.load()
@@ -23,10 +26,51 @@ class CrateDbKnowledgeOutline:
         ```
     """
 
-    @classmethod
-    def read(cls):
-        return resources.read_text("cratedb_about.outline", "cratedb-outline.yaml")
+    url: t.Optional[str] = None
+
+    BUILTIN = resources.files("cratedb_about.outline") / "cratedb-outline.yaml"
+
+    def read(self) -> str:
+        """
+        Load the file from an external URL or the built-in resource.
+
+        Returns:
+            String containing the raw YAML content.
+
+        Raises:
+            FileNotFoundError: If the URL points to a non-existent file.
+            ValueError: If the URL is invalid or the content cannot be parsed.
+        """
+        if self.url is None:
+            return self.BUILTIN.read_text()
+
+        # Import universal I/O interface lazily, because it's only available when
+        # installing the package including its `manyio` extra.
+        from pueblo.io import to_io
+
+        try:
+            with to_io(self.url) as f:
+                return f.read()
+        except FileNotFoundError as e:
+            raise FileNotFoundError(f"Outline file not found: {self.url}") from e
+        except (ValueError, IOError) as e:
+            raise ValueError(f"Failed to read outline from {self.url}: {str(e)}") from e
 
     @classmethod
-    def load(cls) -> "OutlineDocument":
-        return OutlineDocument.from_yaml(cls.read())
+    def load(cls, url: t.Optional[str] = None) -> "OutlineDocument":
+        """
+        Load the outline document from the specified URL or the built-in resource.
+
+        Args:
+            url: Optional URL to load the outline from. Can be a local file path,
+                 an HTTP/HTTPS URL, one of many other remote resources, or None
+                 to use the built-in resource.
+
+        Returns:
+            Parsed OutlineDocument instance.
+
+        Raises:
+            FileNotFoundError: If the URL points to a non-existent file.
+            ValueError: If the URL is invalid or the content cannot be parsed.
+        """
+        return OutlineDocument.from_yaml(cls(url=url).read())

--- a/src/cratedb_about/outline/core.py
+++ b/src/cratedb_about/outline/core.py
@@ -1,0 +1,32 @@
+from importlib import resources
+
+from cratedb_about.outline.model import OutlineDocument
+
+
+class CrateDbKnowledgeOutline:
+    """
+    Load CrateDB knowledge outline from YAML file `cratedb-outline.yaml`.
+
+    This class provides methods to read the raw YAML content and to load it
+    as a structured document model.
+
+    Examples:
+        ```python
+        # Get raw YAML content
+        yaml_content = CrateDbKnowledgeOutline.read()
+
+        # Load as structured document
+        outline = CrateDbKnowledgeOutline.load()
+
+        # Get all section names
+        sections = outline.get_section_names()
+        ```
+    """
+
+    @classmethod
+    def read(cls):
+        return resources.read_text("cratedb_about.outline", "cratedb-outline.yaml")
+
+    @classmethod
+    def load(cls) -> "OutlineDocument":
+        return OutlineDocument.from_yaml(cls.read())

--- a/src/cratedb_about/outline/model.py
+++ b/src/cratedb_about/outline/model.py
@@ -1,40 +1,10 @@
 import typing as t
-from importlib import resources
 from io import StringIO
 
 from attr import Factory
 from attrs import define
 
 from cratedb_about.util import DictTools, Dumpable, Metadata
-
-
-class CrateDbKnowledgeOutline:
-    """
-    Load CrateDB knowledge outline from YAML file `cratedb-outline.yaml`.
-
-    This class provides methods to read the raw YAML content and to load it
-    as a structured document model.
-
-    Examples:
-        ```python
-        # Get raw YAML content
-        yaml_content = CrateDbKnowledgeOutline.read()
-
-        # Load as structured document
-        outline = CrateDbKnowledgeOutline.load()
-
-        # Get all section names
-        sections = outline.get_section_names()
-        ```
-    """
-
-    @classmethod
-    def read(cls):
-        return resources.read_text("cratedb_about.outline", "cratedb-outline.yaml")
-
-    @classmethod
-    def load(cls) -> "OutlineDocument":
-        return OutlineDocument.from_yaml(cls.read())
 
 
 @define

--- a/tests/test-outline.yaml
+++ b/tests/test-outline.yaml
@@ -1,0 +1,28 @@
+# Knowledge outline for testing purposes
+---
+
+meta:
+  version: 0.1
+  type: outline
+
+data:
+
+  header:
+    title: Testing
+    link: https://example.org/
+    description: |
+      > Just for testing purposes.
+
+      Things to remember when working with Testing are:
+
+      - Do it right.
+      - Don't overengineer.
+
+  sections:
+
+  - name: Docs
+    items:
+
+    - title: "Testing README"
+      link: https://example.org/README.rst
+      description: README about Testing.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -44,21 +44,6 @@ def test_cli_list_questions():
     assert "Please tell me how CrateDB stores data." in result.output
 
 
-def test_cli_outline():
-    runner = CliRunner()
-
-    result = runner.invoke(
-        cli,
-        args=["outline", "--format", "markdown"],
-        catch_exceptions=False,
-    )
-    assert result.exit_code == 0, result.output
-
-    assert "# CrateDB" in result.output
-    assert "Things to remember when working with CrateDB" in result.output
-    assert "Concept: Clustering" in result.output
-
-
 def test_cli_build(caplog, tmp_path):
     runner = CliRunner()
 

--- a/tests/test_outline.py
+++ b/tests/test_outline.py
@@ -1,7 +1,7 @@
 import pytest
 
 from cratedb_about import CrateDbKnowledgeOutline
-from cratedb_about.outline.model import OutlineDocument
+from cratedb_about.outline import OutlineDocument
 
 
 @pytest.fixture

--- a/tests/test_outline.py
+++ b/tests/test_outline.py
@@ -1,81 +1,215 @@
 import pytest
+import requests
+from click.testing import CliRunner
 
 from cratedb_about import CrateDbKnowledgeOutline
+from cratedb_about.cli import cli
 from cratedb_about.outline import OutlineDocument
+
+CRATEDB_OUTLINE_FILE = "src/cratedb_about/outline/cratedb-outline.yaml"
+CRATEDB_OUTLINE_URL = "https://github.com/crate/about/raw/refs/tags/v0.0.3/src/cratedb_about/outline/cratedb-outline.yaml"
+
+TESTING_OUTLINE_FILE = "tests/test-outline.yaml"
 
 
 @pytest.fixture
-def cratedb_outline() -> OutlineDocument:
+def cratedb_outline_builtin() -> OutlineDocument:
     return CrateDbKnowledgeOutline.load()
 
 
-def test_outline_get_section_names(cratedb_outline):
-    names = cratedb_outline.get_section_names()
+def test_outline_cli_markdown():
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        args=["outline", "--format", "markdown"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    assert "# CrateDB" in result.output
+    assert "Things to remember when working with CrateDB" in result.output
+    assert "Concept: Clustering" in result.output
+
+
+def test_outline_cli_url_argument():
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        args=["outline", "--url", TESTING_OUTLINE_FILE],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    assert "# Testing" in result.output
+    assert "Things to remember when working with Testing" in result.output
+    assert "Testing README" in result.output
+
+
+def test_outline_cli_url_envvar():
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        args=["outline"],
+        env={"ABOUT_OUTLINE_URL": TESTING_OUTLINE_FILE},
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    assert "# Testing" in result.output
+    assert "Things to remember when working with Testing" in result.output
+    assert "Testing README" in result.output
+
+
+def test_outline_get_section_names(cratedb_outline_builtin):
+    names = cratedb_outline_builtin.get_section_names()
     assert "Docs" in names
     assert "Optional" in names
 
 
-def test_outline_item_titles_all(cratedb_outline):
-    titles = cratedb_outline.get_item_titles()
+def test_outline_item_titles_all(cratedb_outline_builtin):
+    titles = cratedb_outline_builtin.get_item_titles()
     assert "CrateDB reference documentation" in titles
     assert "CrateDB SQL syntax" in titles
     assert "Concept: Resiliency" in titles
     assert len(titles) >= 30
 
 
-def test_outline_item_titles_docs(cratedb_outline):
-    titles = cratedb_outline.get_item_titles(section_name="Docs")
+def test_outline_item_titles_docs(cratedb_outline_builtin):
+    titles = cratedb_outline_builtin.get_item_titles(section_name="Docs")
     assert "CrateDB reference documentation" in titles
     assert len(titles) < 15
 
 
-def test_outline_get_section(cratedb_outline):
-    section_examples = cratedb_outline.get_section("Examples")
+def test_outline_get_section(cratedb_outline_builtin):
+    section_examples = cratedb_outline_builtin.get_section("Examples")
     titles = [item.title for item in section_examples.items]
     assert "CrateDB GTFS / GTFS-RT Transit Data Demo" in titles
 
 
-def test_outline_section_not_found(cratedb_outline):
-    section_not_found = cratedb_outline.get_section("Not Found")
+def test_outline_section_not_found(cratedb_outline_builtin):
+    section_not_found = cratedb_outline_builtin.get_section("Not Found")
     assert section_not_found is None
 
 
-def test_outline_section_items_as_dict(cratedb_outline):
-    items = cratedb_outline.find_items(section_name="Docs", as_dict=True)
+def test_outline_section_items_as_dict(cratedb_outline_builtin):
+    items = cratedb_outline_builtin.find_items(section_name="Docs", as_dict=True)
     assert items[0]["title"] == "CrateDB README"
 
 
-def test_outline_section_items_as_objects(cratedb_outline):
-    items = cratedb_outline.find_items(section_name="Docs")
+def test_outline_section_items_as_objects(cratedb_outline_builtin):
+    items = cratedb_outline_builtin.find_items(section_name="Docs")
     assert items[0].title == "CrateDB README"
 
 
-def test_outline_section_items_not_found(cratedb_outline):
+def test_outline_section_items_not_found(cratedb_outline_builtin):
     with pytest.raises(ValueError) as ex:
-        cratedb_outline.find_items(section_name="Not Found")
+        cratedb_outline_builtin.find_items(section_name="Not Found")
     assert ex.match("Section 'Not Found' not found")
 
 
-def test_outline_section_all_items(cratedb_outline):
-    items = cratedb_outline.find_items()
+def test_outline_section_all_items(cratedb_outline_builtin):
+    items = cratedb_outline_builtin.find_items()
     assert len(items) >= 30
 
 
-def test_outline_find_items_as_dict(cratedb_outline):
-    items = cratedb_outline.find_items(title="gtfs", as_dict=True)
+def test_outline_find_items_as_dict(cratedb_outline_builtin):
+    items = cratedb_outline_builtin.find_items(title="gtfs", as_dict=True)
     assert "Capture GTFS and GTFS-RT data" in items[0]["description"]
 
 
-def test_outline_find_items_as_objects(cratedb_outline):
-    items = cratedb_outline.find_items(title="gtfs")
+def test_outline_find_items_as_objects(cratedb_outline_builtin):
+    items = cratedb_outline_builtin.find_items(title="gtfs")
     assert "Capture GTFS and GTFS-RT data" in items[0].description
 
 
-def test_outline_find_items_not_found_in_section(cratedb_outline):
-    items = cratedb_outline.find_items(title="gtfs", section_name="Docs")
+def test_outline_find_items_not_found_in_section(cratedb_outline_builtin):
+    items = cratedb_outline_builtin.find_items(title="gtfs", section_name="Docs")
     assert items == []
 
 
-def test_outline_find_items_not_found_anywhere(cratedb_outline):
-    items = cratedb_outline.find_items(title="foobar")
+def test_outline_find_items_not_found_anywhere(cratedb_outline_builtin):
+    items = cratedb_outline_builtin.find_items(title="foobar")
     assert items == []
+
+
+def test_outline_with_valid_file_url():
+    outline = CrateDbKnowledgeOutline.load(CRATEDB_OUTLINE_FILE)
+    names = outline.get_section_names()
+    assert "Docs" in names
+    assert "Optional" in names
+
+
+def test_outline_with_valid_http_url():
+    outline = CrateDbKnowledgeOutline.load(CRATEDB_OUTLINE_URL)
+    names = outline.get_section_names()
+    assert "Docs" in names
+    assert "Optional" in names
+
+
+def test_outline_with_invalid_file_url():
+    with pytest.raises(FileNotFoundError) as ex:
+        CrateDbKnowledgeOutline.load("foobar.yaml")
+    assert ex.match("Outline file not found: foobar.yaml")
+
+
+def test_outline_with_invalid_http_url(monkeypatch):
+    # Simulate a 404 response for an HTTP URL
+    class FakeResponse:
+        status_code = 404
+        raise_for_status = lambda self: (_ for _ in ()).throw(requests.HTTPError("404 Not Found"))  # noqa: E731
+
+    monkeypatch.setattr(requests, "get", lambda *_: FakeResponse())
+    with pytest.raises(FileNotFoundError) as ex:
+        CrateDbKnowledgeOutline.load("https://example.com/not-found.yaml")
+    assert ex.match("Outline file not found")
+
+
+def test_outline_with_non_yaml_content(tmp_path):
+    non_yaml = tmp_path / "bad.txt"
+    non_yaml.write_text("not: valid: yaml: [")
+    with pytest.raises(Exception) as ex:
+        CrateDbKnowledgeOutline.load(str(non_yaml))
+    assert "YAML" in str(ex.value) or "mapping" in str(ex.value)
+
+
+def test_outline_with_auth_required_http_url(monkeypatch):
+    # Simulate a 401 response
+    class Unauthorized:
+        status_code = 401
+        raise_for_status = lambda self: (_ for _ in ()).throw(  # noqa: E731
+            requests.HTTPError("401 Unauthorized")
+        )
+
+    monkeypatch.setattr(requests, "get", lambda *_: Unauthorized())
+    with pytest.raises(FileNotFoundError) as ex:
+        CrateDbKnowledgeOutline.load("https://secure.example.com/outline.yaml")
+    assert ex.match("Outline file not found")
+
+
+def test_outline_with_io_error(monkeypatch):
+    """Test that CrateDbKnowledgeOutline.read() properly handles IOError."""
+
+    # Mock the to_io function to raise IOError
+    def mock_to_io(url):
+        class MockContextManager:
+            def __enter__(self):
+                raise IOError("Simulated IO error")
+
+            def __exit__(self, exc_type, exc_val, exc_tb):
+                pass
+
+        return MockContextManager()
+
+    monkeypatch.setattr("pueblo.io.to_io", mock_to_io)
+
+    # Create outline instance with a URL and verify exception
+    outline = CrateDbKnowledgeOutline(url="dummy://url")
+    with pytest.raises(ValueError) as excinfo:
+        outline.read()
+
+    # Verify error message format
+    assert str(excinfo.value).startswith("Failed to read outline from dummy://url:")
+    assert "Simulated IO error" in str(excinfo.value)


### PR DESCRIPTION
... to load any outline resource on local and remote filesystems.