### PR TITLE
Query: Permit loading context file from local filesystem

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
 - Bundle: Started accepting `--url`/`ABOUT_OUTLINE_URL` option to specify
   alternative input outline file
 - Bundle: Improved handling of `--format` option
+- Query: Permitted loading context file from local filesystem
+  per `ABOUT_CONTEXT_URL`
 
 ## v0.0.3 - 2025-05-10
 - Outline: Refactored the source of truth for the documentation outline

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ cratedb-about list-questions
 
 To configure a different context file, use the `ABOUT_CONTEXT_URL` environment
 variable. It can be a remote URL or a path on the local filesystem.
-The default value is https://cdn.crate.io/about/v1/llms-full.txt.
+The default value is <https://cdn.crate.io/about/v1/llms-full.txt>.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ cratedb-about list-questions
 ```
 
 To configure a different context file, use the `ABOUT_CONTEXT_URL` environment
-variable. The default value is https://cdn.crate.io/about/v1/llms-full.txt.
+variable. It can be a remote URL or a path on the local filesystem.
+The default value is https://cdn.crate.io/about/v1/llms-full.txt.
 
 ## FAQ
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+# https://docs.codecov.io/docs/common-recipe-list
+# https://docs.codecov.io/docs/commit-status#patch-status
+
+coverage:
+  status:
+
+    project:
+      default:
+        target: 85%
+
+    patch:
+      default:
+        informational: true

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -6,6 +6,9 @@
   https://github.com/crate/about/issues/24
 - Outline: Explore using refined content representations by
   pulling in `ctk docs functions` and `ctk docs settings`
+- llms-txt: Compare sizes of CrateDB's `llms.txt` against sizes
+  of other vendors. Adjust when needed.
+  https://github.com/crate/about/issues/20
 
 ## Iteration +2
 - Any: JSON/YAML/Markdown output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ optional-dependencies.test = [
   "pytest<9",
   "pytest-cov<7",
   "pytest-mock<4",
+  "requests-mock<2",
 ]
 urls.Changelog = "https://github.com/crate/about/blob/main/CHANGES.md"
 urls.Issues = "https://github.com/crate/about/issues"

--- a/src/cratedb_about/query/model.py
+++ b/src/cratedb_about/query/model.py
@@ -34,6 +34,10 @@ class Example:
         "Tell me about the health of the cluster.",
         "What is the storage consumption of my tables, give it in a graph.",
         "How can I format a timestamp column to '2019 Jan 21'?",
+        "Please tell me about integrations with CrateDB.",
+        "How do I use SQLAlchemy with CrateDB?",
+        "How do I use pandas with CrateDB?",
+        "How do I optimally synchronize data between MongoDB and CrateDB?",
     ]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,5 +6,11 @@ import pytest
 @pytest.fixture(scope="session", autouse=True)
 def prune_environ():
     """Prevent environment variables from leaking into software tests"""
-    os.environ.pop("OPENAI_API_KEY", None)
-    os.environ.pop("OUTDIR", None)
+    candidates = [
+        "ABOUT_CONTEXT_URL",
+        "ABOUT_OUTLINE_URL",
+        "OPENAI_API_KEY",
+        "OUTDIR",
+    ]
+    for candidate in candidates:
+        os.environ.pop(candidate, None)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -80,3 +80,53 @@ def test_settings_context_url_default():
 def test_settings_context_url_env(mocker):
     mocker.patch.dict("os.environ", {"ABOUT_CONTEXT_URL": "http://example.com"})
     assert Settings.llms_txt_url == "http://example.com"
+
+
+def test_llms_txt_payload_from_file(tmp_path, monkeypatch):
+    # Create a temporary file with known content.
+    test_file = tmp_path / "test_context.txt"
+    test_content = "Test CrateDB context content"
+    test_file.write_text(test_content)
+
+    # Point `ABOUT_CONTEXT_URL` to the temporary file.
+    monkeypatch.setenv("ABOUT_CONTEXT_URL", str(test_file))
+
+    # Verify the classproperty correctly reads the file.
+    assert Settings.llms_txt_payload == test_content
+
+
+def test_llms_txt_payload_from_http(monkeypatch, requests_mock):
+    # Mock HTTP URL and response.
+    test_url = "http://example.com/context.txt"
+    test_content = "Test CrateDB HTTP content"
+    requests_mock.get(test_url, text=test_content)
+
+    # Set the environment variable to the HTTP URL.
+    # Point `ABOUT_CONTEXT_URL` to the temporary URL.
+    monkeypatch.setenv("ABOUT_CONTEXT_URL", test_url)
+
+    # Verify HTTP request is made and content is returned.
+    assert Settings.llms_txt_payload == test_content
+
+
+def test_llms_txt_payload_invalid_source(monkeypatch):
+    # Set the environment variable to an invalid path.
+    monkeypatch.setenv("ABOUT_CONTEXT_URL", "/non/existent/path/that/is/not/http")
+
+    # Verify appropriate error is raised.
+    with pytest.raises(NotImplementedError) as ex:
+        _ = Settings.llms_txt_payload
+    assert ex.match("Unable to load context file. Source:")
+
+
+def test_get_prompt_exception_handling(monkeypatch, mocker):
+    # Mock llms_txt_payload to raise an exception.
+    mocker.patch.object(Settings, "llms_txt_payload", lambda x: Exception("Test error"))
+
+    # Call get_prompt and verify fallback behavior
+    Settings.llms_txt = None
+    result = Settings.get_prompt()
+
+    # Verify fallback context is used
+    assert Settings.default_context in result
+    assert "minimal context" in result


### PR DESCRIPTION
## About

`ABOUT_CONTEXT_URL` was limited to HTTP URLs before. Now, it also accepts a filesystem path.
