### PR TITLE
Bundle: Start accepting `--url`/`ABOUT_OUTLINE_URL` option

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@
 - Outline: Significantly update `cratedb-outline.yaml`
 - Bundle: Started accepting `--url`/`ABOUT_OUTLINE_URL` option to specify
   alternative input outline file
+- Bundle: Improved handling of `--format` option
 
 ## v0.0.3 - 2025-05-10
 - Outline: Refactored the source of truth for the documentation outline

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
 - Outline: Renamed `CRATEDB_CONTEXT_URL` to `ABOUT_CONTEXT_URL`
 - Outline: Fixed `llms_txt` currently does not accept newlines in description fields
 - Outline: Significantly update `cratedb-outline.yaml`
+- Bundle: Started accepting `--url`/`ABOUT_OUTLINE_URL` option to specify
+  alternative input outline file
 
 ## v0.0.3 - 2025-05-10
 - Outline: Refactored the source of truth for the documentation outline

--- a/README.md
+++ b/README.md
@@ -153,9 +153,12 @@ The Markdown file `outline.md` serves as the source for producing the
 `llms.txt` files. Generate multiple `llms.txt` files along with any
 auxiliary output files.
 ```shell
-export OUTDIR=./public_html
-cratedb-about bundle --format=llms-txt
+cratedb-about bundle --format=llms-txt --outdir=./public_html
 ```
+By default, the bundler will use the built-in `cratedb-outline.yaml` as input file.
+You can select an alternative input file using the `--url` option, or the
+`ABOUT_OUTLINE_URL` environment variable. The output directory can
+also be specified using the `OUTDIR` environment variable.
 
 ### Query
 Ask questions about CrateDB from the command line.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The Markdown file `outline.md` serves as the source for producing the
 `llms.txt` files. Generate multiple `llms.txt` files along with any
 auxiliary output files.
 ```shell
-cratedb-about bundle --format=llms-txt --outdir=./public_html
+cratedb-about bundle --format=llm --outdir=./public_html
 ```
 By default, the bundler will use the built-in `cratedb-outline.yaml` as input file.
 You can select an alternative input file using the `--url` option, or the

--- a/src/cratedb_about/bundle/llmstxt.py
+++ b/src/cratedb_about/bundle/llmstxt.py
@@ -20,7 +20,7 @@ class LllmsTxtBuilder:
     outdir: Path
 
     def run(self):
-        logger.info(f"Bundling llms-txt. Output directory: {self.outdir}")
+        logger.info(f"Creating bundle. Format: llms-txt. Output directory: {self.outdir}")
         self.outdir.mkdir(parents=True, exist_ok=True)
 
         logger.info("Copying source and documentation files")

--- a/src/cratedb_about/bundle/llmstxt.py
+++ b/src/cratedb_about/bundle/llmstxt.py
@@ -16,6 +16,7 @@ class LllmsTxtBuilder:
     Build llms.txt files for CrateDB.
     """
 
+    outline_url: str
     outdir: Path
 
     def run(self):
@@ -34,6 +35,6 @@ class LllmsTxtBuilder:
 
         # TODO: Explore how to optimize this procedure that both steps do not need
         #       to acquire and process data redundantly.
-        outline = CrateDbKnowledgeOutline.load()
+        outline = CrateDbKnowledgeOutline.load(self.outline_url)
         Path(self.outdir / "llms.txt").write_text(outline.to_llms_txt())
         Path(self.outdir / "llms-full.txt").write_text(outline.to_llms_txt(optional=True))

--- a/src/cratedb_about/cli.py
+++ b/src/cratedb_about/cli.py
@@ -72,7 +72,12 @@ def outline(
 @cli.command()
 @outline_url_option
 @click.option(
-    "--format", "-f", "format_", type=str, default="llms-txt", help="Output format: Use llms-txt"
+    "--format",
+    "-f",
+    "format_",
+    type=click.Choice(["llm"]),
+    required=True,
+    help="Bundle output format",
 )
 @click.option("--outdir", "-o", envvar="OUTDIR", type=Path, required=True)
 @click.pass_context
@@ -80,7 +85,7 @@ def bundle(ctx: click.Context, url: str, format_: str, outdir: Path) -> None:
     """
     Invoke the bundling. For now: Generate multiple `llms.txt` files.
     """
-    if format_ != "llms-txt":
+    if format_ != "llm":
         raise click.BadOptionUsage("format", f"Invalid output format: {format_}", ctx=ctx)
     builder = LllmsTxtBuilder(outline_url=url, outdir=outdir)
     builder.run()

--- a/src/cratedb_about/cli.py
+++ b/src/cratedb_about/cli.py
@@ -13,15 +13,7 @@ from cratedb_about.query.model import Example
 logger = logging.getLogger(__name__)
 
 
-@click.group()
-@click.version_option()
-@click.pass_context
-def cli(ctx: click.Context) -> None:
-    boot_click(ctx=ctx)
-
-
-@cli.command()
-@click.option(
+outline_url_option = click.option(
     "--url",
     "-u",
     envvar="ABOUT_OUTLINE_URL",
@@ -30,6 +22,17 @@ def cli(ctx: click.Context) -> None:
     default=None,
     help="URL to the outline file. By default, the built-in outline is used.",
 )
+
+
+@click.group()
+@click.version_option()
+@click.pass_context
+def cli(ctx: click.Context) -> None:
+    boot_click(ctx=ctx)
+
+
+@cli.command()
+@outline_url_option
 @click.option(
     "--format",
     "-f",
@@ -67,18 +70,19 @@ def outline(
 
 
 @cli.command()
+@outline_url_option
 @click.option(
     "--format", "-f", "format_", type=str, default="llms-txt", help="Output format: Use llms-txt"
 )
 @click.option("--outdir", "-o", envvar="OUTDIR", type=Path, required=True)
 @click.pass_context
-def bundle(ctx: click.Context, format_: str, outdir: Path) -> None:
+def bundle(ctx: click.Context, url: str, format_: str, outdir: Path) -> None:
     """
     Invoke the bundling. For now: Generate multiple `llms.txt` files.
     """
     if format_ != "llms-txt":
         raise click.BadOptionUsage("format", f"Invalid output format: {format_}", ctx=ctx)
-    builder = LllmsTxtBuilder(outdir=outdir)
+    builder = LllmsTxtBuilder(outline_url=url, outdir=outdir)
     builder.run()
     logger.info("Ready.")
 

--- a/tests/assets/outline.yaml
+++ b/tests/assets/outline.yaml
@@ -23,9 +23,9 @@ data:
   - name: Docs
     items:
 
-    - title: "Testing README"
-      link: https://example.org/README.rst
-      description: README about Testing.
+    - title: "Example Domain"
+      link: https://example.org/
+      description: Example Domain.
 
   - name: Optional
     items:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from click.testing import CliRunner
 
 from cratedb_about.cli import cli
+from tests.test_outline import TESTING_OUTLINE_FILE
 
 
 def test_cli_version():
@@ -44,14 +45,14 @@ def test_cli_list_questions():
     assert "Please tell me how CrateDB stores data." in result.output
 
 
-def test_cli_bundle(caplog, tmp_path):
+def test_cli_bundle_success(caplog, tmp_path):
     runner = CliRunner()
 
     # Invoke command.
     result = runner.invoke(
         cli,
         args=["bundle"],
-        env={"OUTDIR": str(tmp_path)},
+        env={"ABOUT_OUTLINE_URL": TESTING_OUTLINE_FILE, "OUTDIR": str(tmp_path)},
         catch_exceptions=False,
     )
     assert result.exit_code == 0, result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -51,14 +51,14 @@ def test_cli_bundle_success(caplog, tmp_path):
     # Invoke command.
     result = runner.invoke(
         cli,
-        args=["bundle"],
+        args=["bundle", "--format", "llm"],
         env={"ABOUT_OUTLINE_URL": TESTING_OUTLINE_FILE, "OUTDIR": str(tmp_path)},
         catch_exceptions=False,
     )
     assert result.exit_code == 0, result.output
 
     # Verify log output.
-    assert "Bundling llms-txt" in caplog.text
+    assert "Creating bundle. Format: llms-txt" in caplog.text
     assert "Ready." in caplog.text
 
     # Verify that the expected output files have been created.
@@ -72,7 +72,7 @@ def test_cli_bundle_without_outdir():
     # Invoke command without OUTDIR environment variable.
     result = runner.invoke(
         cli,
-        args=["bundle"],
+        args=["bundle", "--format", "llm"],
         env={},  # No OUTDIR set
         catch_exceptions=False,
     )
@@ -80,6 +80,22 @@ def test_cli_bundle_without_outdir():
     # Verify appropriate error handling.
     assert result.exit_code != 0, result.output
     assert "Error: Missing option '--outdir' / '-o'" in result.output
+
+
+def test_cli_bundle_without_format(tmp_path):
+    runner = CliRunner()
+
+    # Invoke command.
+    result = runner.invoke(
+        cli,
+        args=["bundle"],
+        env={"OUTDIR": str(tmp_path)},
+        catch_exceptions=False,
+    )
+
+    # Verify appropriate error handling.
+    assert result.exit_code != 0, result.output
+    assert "Error: Missing option '--format' / '-f'" in result.output
 
 
 def test_cli_bundle_invalid_format(tmp_path):
@@ -95,4 +111,4 @@ def test_cli_bundle_invalid_format(tmp_path):
 
     # Verify appropriate error handling.
     assert result.exit_code != 0, result.output
-    assert "Error: Invalid output format: foobar" in result.output
+    assert "Error: Invalid value for '--format' / '-f': 'foobar' is not 'llm'" in result.output

--- a/tests/test_outline.py
+++ b/tests/test_outline.py
@@ -106,7 +106,7 @@ def test_outline_cli_url_argument():
 
     assert "# Testing" in result.output
     assert "Things to remember when working with Testing" in result.output
-    assert "Testing README" in result.output
+    assert "Example Domain" in result.output
 
 
 def test_outline_cli_url_envvar():
@@ -122,7 +122,7 @@ def test_outline_cli_url_envvar():
 
     assert "# Testing" in result.output
     assert "Things to remember when working with Testing" in result.output
-    assert "Testing README" in result.output
+    assert "Example Domain" in result.output
 
 
 def test_outline_get_section_names(cratedb_outline_builtin):


### PR DESCRIPTION
The `--url` option was missing with the `bundle` subcommand yet. Now that it exists, it can be used to relax testing by not using the production outline file, no longer causing sporadic timeout errors.