### PR TITLE
Bundle: Fix semantics of `llms.txt` vs. `llms-full.txt`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
 - Inventory: Added information about SQL data types and about how to import
   example datasets using CrateDB Toolkit.
 - Bundle: Fixed semantics of `llms.txt` vs. `llms-full.txt`, see [ABOUT-39].
+- Bundle: Generated `outline.html` for improved inspection by humans
 
 [ABOUT-39]: https://github.com/crate/about/issues/39
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@
   `{CREATE,ALTER} [FOREIGN] TABLE [AS]` and `COPY {FROM,TO}` commands.
 - Inventory: Added information about SQL data types and about how to import
   example datasets using CrateDB Toolkit.
+- Bundle: Fixed semantics of `llms.txt` vs. `llms-full.txt`, see [ABOUT-39].
+
+[ABOUT-39]: https://github.com/crate/about/issues/39
 
 ## v0.0.4 - 2025-05-16
 - Outline: `cratedb-about outline` now understands `--url` option to use

--- a/src/cratedb_about/bundle/llmstxt.py
+++ b/src/cratedb_about/bundle/llmstxt.py
@@ -71,6 +71,7 @@ class LllmsTxtBuilder:
             str(self.outline_yaml),
             self.outdir / "outline.yaml",
         )
+        Path(self.outdir / "outline.html").write_text(self.outline.to_html())
 
 
 @dataclasses.dataclass

--- a/src/cratedb_about/bundle/llmstxt.py
+++ b/src/cratedb_about/bundle/llmstxt.py
@@ -1,7 +1,6 @@
 import dataclasses
 import logging
 import shutil
-import typing as t
 from importlib import resources
 from importlib.abc import Traversable
 from pathlib import Path
@@ -9,6 +8,7 @@ from pathlib import Path
 from markdown import markdown
 
 from cratedb_about import CrateDbKnowledgeOutline
+from cratedb_about.outline import OutlineDocument
 from cratedb_about.util import get_hostname, get_now
 
 logger = logging.getLogger(__name__)
@@ -17,12 +17,15 @@ logger = logging.getLogger(__name__)
 @dataclasses.dataclass
 class LllmsTxtBuilder:
     """
-    Build llms.txt files for CrateDB.
+    Generate llms.txt files.
+
+    This is a base class intended to be subclassed. The non-init fields
+    (outline, readme_md, outline_yaml) should be initialized by subclasses.
     """
 
     outline_url: str
     outdir: Path
-    outline: t.Any = dataclasses.field(init=False)
+    outline: OutlineDocument = dataclasses.field(init=False)
     readme_md: Traversable = dataclasses.field(init=False)
     outline_yaml: Traversable = dataclasses.field(init=False)
 
@@ -71,13 +74,16 @@ class LllmsTxtBuilder:
             str(self.outline_yaml),
             self.outdir / "outline.yaml",
         )
-        Path(self.outdir / "outline.html").write_text(self.outline.to_html())
+        try:
+            Path(self.outdir / "outline.html").write_text(self.outline.to_html())
+        except Exception as e:
+            logger.warning(f"Failed to generate HTML outline: {e}")
 
 
 @dataclasses.dataclass
 class CrateDbLllmsTxtBuilder(LllmsTxtBuilder):
     """
-    Build llms.txt files for CrateDB.
+    Generate llms.txt files for CrateDB.
     """
 
     readme_md: Traversable = resources.files("cratedb_about.bundle") / "readme.md"

--- a/src/cratedb_about/cli.py
+++ b/src/cratedb_about/cli.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import click
 from pueblo.util.cli import boot_click
 
-from cratedb_about.bundle.llmstxt import LllmsTxtBuilder
+from cratedb_about.bundle.llmstxt import CrateDbLllmsTxtBuilder
 from cratedb_about.outline import CrateDbKnowledgeOutline
 from cratedb_about.query.core import CrateDbKnowledgeConversation
 from cratedb_about.query.model import Example
@@ -95,7 +95,7 @@ def bundle(ctx: click.Context, url: str, format_: str, outdir: Path) -> None:
     """
     if format_ != "llm":
         raise click.BadOptionUsage("format", f"Invalid output format: {format_}", ctx=ctx)
-    LllmsTxtBuilder(outline_url=url, outdir=outdir).run()
+    CrateDbLllmsTxtBuilder(outline_url=url, outdir=outdir).run()
     logger.info("Ready.")
 
 

--- a/src/cratedb_about/outline/model.py
+++ b/src/cratedb_about/outline/model.py
@@ -81,6 +81,9 @@ class OutlineDocument(Dumpable):
         return buffer.getvalue().strip()
 
     def to_html(self) -> str:
+        """
+        Convert outline into HTML format using Markdown as an intermediate step.
+        """
         return markdown(self.to_markdown())
 
     def to_llms_txt(self, optional: bool = False) -> str:

--- a/src/cratedb_about/outline/model.py
+++ b/src/cratedb_about/outline/model.py
@@ -4,6 +4,7 @@ from unittest import mock
 
 from attr import Factory
 from attrs import define
+from markdown import markdown
 
 from cratedb_about.util import DictTools, Dumpable, Metadata, get_cache_client
 
@@ -78,6 +79,9 @@ class OutlineDocument(Dumpable):
                 buffer.write(f"- [{item.title}]({item.link}): {item.description}\n")
             buffer.write("\n")
         return buffer.getvalue().strip()
+
+    def to_html(self) -> str:
+        return markdown(self.to_markdown())
 
     def to_llms_txt(self, optional: bool = False) -> str:
         """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -65,7 +65,7 @@ def test_cli_bundle_success(caplog, tmp_path):
     assert (tmp_path / "readme.md").exists()
     assert (tmp_path / "readme.html").exists()
     assert (tmp_path / "outline.yaml").exists()
-    assert (tmp_path / "outline.md").exists()
+    assert (tmp_path / "outline.html").exists()
     assert (tmp_path / "llms.txt").exists()
     assert (tmp_path / "llms-full.txt").exists()
 


### PR DESCRIPTION
## Problem

The current [llms.txt](https://cdn.crate.io/about/v1/llms.txt) was wrong. Many other publications demonstrate it should be a Markdown file with referenced content NOT inlined.

## References

- GH-39
